### PR TITLE
PHP 8 Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: [7.2, 7.3, 7.4]
+                php: [7.2, 7.3, 7.4, 8.0]
                 laravel: [5.8.*, 6.*, 7.*, 8.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require" : {
-        "php" : "^7.2",
+        "php" : "^7.2|^8.0",
         "illuminate/database" : "~5.8.0|^6.0|^7.0|^8.0",
         "illuminate/routing" : "~5.8.0|^6.0|^7.0|^8.0"
     },

--- a/src/ParameterResolver.php
+++ b/src/ParameterResolver.php
@@ -61,14 +61,14 @@ class ParameterResolver
             return $this->searchPrimitiveParameter($signatureParameter, $providedParameters);
         }
 
-        foreach ($providedParameters as $index => $providedParameter) {
-            if (! is_object($providedParameter) || $signatureParameter->getType()->getName() === null) {
-                continue;
-            }
-
-            $reflectionClass = $signatureParameter->getType() && !$signatureParameter->getType()->isBuiltin()
+        $reflectionClass = $signatureParameter->getType() && !$signatureParameter->getType()->isBuiltin()
                 ? new ReflectionClass($signatureParameter->getType()->getName())
                 : null;
+
+        foreach ($providedParameters as $index => $providedParameter) {
+            if (! is_object($providedParameter) || $reflectionClass === null) {
+                continue;
+            }
 
             if (!is_null($reflectionClass) && $reflectionClass->isInstance($providedParameter)) {
                 return Arr::pull($providedParameters, $index);

--- a/src/ParameterResolver.php
+++ b/src/ParameterResolver.php
@@ -65,8 +65,8 @@ class ParameterResolver
                 ? new ReflectionClass($signatureParameter->getType()->getName())
                 : null;
 
-        foreach ($providedParameters as $index => $providedParameter) {
-            if (! is_object($providedParameter) || $reflectionClass === null) {
+        if (!is_object($providedParameter) || $reflectionClass === null) {
+            if (!is_object($providedParameter) || $reflectionClass === null) {
                 continue;
             }
 

--- a/src/ParameterResolver.php
+++ b/src/ParameterResolver.php
@@ -65,7 +65,7 @@ class ParameterResolver
                 ? new ReflectionClass($signatureParameter->getType()->getName())
                 : null;
 
-        if (!is_object($providedParameter) || $reflectionClass === null) {
+        foreach ($providedParameters as $index => $providedParameter) {
             if (!is_object($providedParameter) || $reflectionClass === null) {
                 continue;
             }


### PR DESCRIPTION
As is the package does not support PHP 8.

This PR addresses the issue of `ReflectionParameter::getClass()` deprecation allowing the support of PHP 8.

If there are any changes needed, or issues with this PR please let me know and I'll be more than glad to correct them.